### PR TITLE
Add opus get previous packet mode and cgo annotations

### DIFF
--- a/0001-Add-OPUS_GET_PREVSIGNALTYPE_REQUEST-to-opus_decoder_.patch
+++ b/0001-Add-OPUS_GET_PREVSIGNALTYPE_REQUEST-to-opus_decoder_.patch
@@ -1,8 +1,8 @@
 From 8a1acea2d45a455866be54f71833545fd1670f66 Mon Sep 17 00:00:00 2001
 From: Matthew MacGregor <matthew.macgregor@verkada.com>
 Date: Thu, 31 Jul 2025 16:05:25 -0700
-Subject: [PATCH] Add OPUS_GET_PREVSIGNALTYPE_REQUEST to opus_decoder_ctl and
- opus_encoder_ctl
+Subject: [PATCH 1/2] Add OPUS_GET_PREVSIGNALTYPE_REQUEST to opus_decoder_ctl
+ and opus_encoder_ctl
 
 ---
  include/opus_defines.h |  3 +++

--- a/0002-Add-OPUS_GET_PREVMODE_REQUEST-to-opus_decoder_ctl-an.patch
+++ b/0002-Add-OPUS_GET_PREVMODE_REQUEST-to-opus_decoder_ctl-an.patch
@@ -1,0 +1,97 @@
+From 5cadfaeb52d903985cfa1c58fc808812038afea4 Mon Sep 17 00:00:00 2001
+From: Matthew MacGregor <matthew.macgregor@verkada.com>
+Date: Sun, 10 Aug 2025 20:20:53 -0400
+Subject: [PATCH 2/2] Add OPUS_GET_PREVMODE_REQUEST to opus_decoder_ctl and
+ opus_encoder_ctl
+
+---
+ include/opus_defines.h |  7 +++++++
+ src/opus_decoder.c     | 10 ++++++++++
+ src/opus_encoder.c     |  9 +++++++++
+ src/opus_private.h     |  4 ----
+ 4 files changed, 26 insertions(+), 4 deletions(-)
+
+diff --git a/include/opus_defines.h b/include/opus_defines.h
+index 5f4dfc69..07dccf95 100644
+--- a/include/opus_defines.h
++++ b/include/opus_defines.h
+@@ -174,6 +174,11 @@ extern "C" {
+ #define OPUS_SET_DNN_BLOB_REQUEST 4052
+ /*#define OPUS_GET_DNN_BLOB_REQUEST 4053 */
+ #define OPUS_GET_PREVSIGNALTYPE_REQUEST 4054
++#define OPUS_GET_PREVMODE_REQUEST 4055
++
++#define MODE_SILK_ONLY          1000
++#define MODE_HYBRID             1001
++#define MODE_CELT_ONLY          1002
+ 
+ /** Defines for the presence of extended APIs. */
+ #define OPUS_HAVE_OPUS_PROJECTION_H
+@@ -727,6 +732,8 @@ extern "C" {
+ 
+ #define OPUS_GET_PREVSIGNALTYPE(x) OPUS_GET_PREVSIGNALTYPE_REQUEST, __opus_check_int_ptr(x)
+ 
++#define OPUS_GET_PREVMODE(x) OPUS_GET_PREVMODE_REQUEST, __opus_check_int_ptr(x)
++
+ /** If set to 1, disables the use of phase inversion for intensity stereo,
+   * improving the quality of mono downmixes, but slightly reducing normal
+   * stereo quality. Disabling phase inversion in the decoder does not comply
+diff --git a/src/opus_decoder.c b/src/opus_decoder.c
+index b92841b8..ad3ea657 100644
+--- a/src/opus_decoder.c
++++ b/src/opus_decoder.c
+@@ -918,6 +918,16 @@ int opus_decoder_ctl(OpusDecoder *st, int request, ...)
+ 
+    switch (request)
+    {
++   case OPUS_GET_PREVMODE_REQUEST:
++   {
++      opus_int32 *value = va_arg(ap, opus_int32*);
++      if (!value)
++      {
++         goto bad_arg;
++      }
++      *value = st->prev_mode;
++   }
++   break;
+    case OPUS_GET_PREVSIGNALTYPE_REQUEST:
+    {
+       opus_int32 *value = va_arg(ap, opus_int32*);
+diff --git a/src/opus_encoder.c b/src/opus_encoder.c
+index 7783ddf4..6fdef0f1 100644
+--- a/src/opus_encoder.c
++++ b/src/opus_encoder.c
+@@ -2543,6 +2543,15 @@ int opus_encoder_ctl(OpusEncoder *st, int request, ...)
+ 
+     switch (request)
+     {
++        case OPUS_GET_PREVMODE_REQUEST:
++        {
++           opus_int32 *value = va_arg(ap, opus_int32*);
++           if (!value)
++           {
++              goto bad_arg;
++           }
++           *value = st->prev_mode;
++        }
+         case OPUS_GET_PREVSIGNALTYPE_REQUEST:
+         {
+             opus_int32 *value = va_arg(ap, opus_int32*);
+diff --git a/src/opus_private.h b/src/opus_private.h
+index 279f5f95..c63f654c 100644
+--- a/src/opus_private.h
++++ b/src/opus_private.h
+@@ -114,10 +114,6 @@ typedef void (*opus_copy_channel_out_func)(
+   void *user_data
+ );
+ 
+-#define MODE_SILK_ONLY          1000
+-#define MODE_HYBRID             1001
+-#define MODE_CELT_ONLY          1002
+-
+ #define OPUS_SET_VOICE_RATIO_REQUEST         11018
+ #define OPUS_GET_VOICE_RATIO_REQUEST         11019
+ 
+-- 
+2.39.5 (Apple Git-154)
+

--- a/decoder.go
+++ b/decoder.go
@@ -24,6 +24,12 @@ bridge_decoder_get_prev_signal_type(OpusDecoder *st, opus_int32 *prev_signal_typ
 {
         return opus_decoder_ctl(st, OPUS_GET_PREVSIGNALTYPE(prev_signal_type));
 }
+
+int
+bridge_decoder_get_prev_mode(OpusDecoder *st, opus_int32 *prev_mode)
+{
+        return opus_decoder_ctl(st, OPUS_GET_PREVMODE(prev_mode));
+}
 */
 import "C"
 
@@ -274,4 +280,13 @@ func (dec *Decoder) PrevSignalType() (int, error) {
 		return 0, Error(res)
 	}
 	return int(prev_signal_type), nil
+}
+
+func (dec *Decoder) PrevMode() (int, error) {
+	var prev_mode C.opus_int32
+	res := C.bridge_decoder_get_prev_mode(dec.p, &prev_mode)
+	if res != C.OPUS_OK {
+		return 0, Error(res)
+	}
+	return int(prev_mode), nil
 }

--- a/decoder.go
+++ b/decoder.go
@@ -11,20 +11,27 @@ import (
 
 /*
 #cgo pkg-config: opus
+
 #include <opus.h>
 
+#cgo noescape bridge_decoder_get_last_packet_duration
+#cgo nocallback bridge_decoder_get_last_packet_duration
 int
 bridge_decoder_get_last_packet_duration(OpusDecoder *st, opus_int32 *samples)
 {
 	return opus_decoder_ctl(st, OPUS_GET_LAST_PACKET_DURATION(samples));
 }
 
+#cgo noescape bridge_decoder_get_prev_signal_type
+#cgo nocallback bridge_decoder_get_prev_signal_type
 int
 bridge_decoder_get_prev_signal_type(OpusDecoder *st, opus_int32 *prev_signal_type)
 {
         return opus_decoder_ctl(st, OPUS_GET_PREVSIGNALTYPE(prev_signal_type));
 }
 
+#cgo noescape bridge_decoder_get_prev_mode
+#cgo nocallback bridge_decoder_get_prev_mode
 int
 bridge_decoder_get_prev_mode(OpusDecoder *st, opus_int32 *prev_mode)
 {

--- a/encoder.go
+++ b/encoder.go
@@ -110,6 +110,11 @@ bridge_encoder_get_prev_signal_type(OpusEncoder *st, opus_int32 *prev_signal_typ
 	return opus_encoder_ctl(st, OPUS_GET_PREVSIGNALTYPE(prev_signal_type));
 }
 
+int
+bridge_encoder_get_prev_mode(OpusEncoder *st, opus_int32 *prev_mode)
+{
+        return opus_encoder_ctl(st, OPUS_GET_PREVMODE(prev_mode));
+}
 */
 import "C"
 
@@ -414,4 +419,13 @@ func (enc *Encoder) PrevSignalType() (int, error) {
 		return 0, Error(res)
 	}
 	return int(prev_signal_type), nil
+}
+
+func (enc *Encoder) PrevMode() (int, error) {
+	var prev_mode C.opus_int32
+	res := C.bridge_encoder_get_prev_mode(enc.p, &prev_mode)
+	if res != C.OPUS_OK {
+		return 0, Error(res)
+	}
+	return int(prev_mode), nil
 }

--- a/encoder.go
+++ b/encoder.go
@@ -13,24 +13,32 @@ import (
 #cgo pkg-config: opus
 #include <opus.h>
 
+#cgo noescape bridge_encoder_set_dtx
+#cgo nocallback bridge_encoder_set_dtx
 int
 bridge_encoder_set_dtx(OpusEncoder *st, opus_int32 use_dtx)
 {
 	return opus_encoder_ctl(st, OPUS_SET_DTX(use_dtx));
 }
 
+#cgo noescape bridge_encoder_get_dtx
+#cgo nocallback bridge_encoder_get_dtx
 int
 bridge_encoder_get_dtx(OpusEncoder *st, opus_int32 *dtx)
 {
 	return opus_encoder_ctl(st, OPUS_GET_DTX(dtx));
 }
 
+#cgo noescape bridge_encoder_get_in_dtx
+#cgo nocallback bridge_encoder_get_in_dtx
 int
 bridge_encoder_get_in_dtx(OpusEncoder *st, opus_int32 *in_dtx)
 {
 	return opus_encoder_ctl(st, OPUS_GET_IN_DTX(in_dtx));
 }
 
+#cgo noescape bridge_encoder_get_sample_rate
+#cgo nocallback bridge_encoder_get_sample_rate
 int
 bridge_encoder_get_sample_rate(OpusEncoder *st, opus_int32 *sample_rate)
 {
@@ -38,78 +46,104 @@ bridge_encoder_get_sample_rate(OpusEncoder *st, opus_int32 *sample_rate)
 }
 
 
+#cgo noescape bridge_encoder_set_bitrate
+#cgo nocallback bridge_encoder_set_bitrate
 int
 bridge_encoder_set_bitrate(OpusEncoder *st, opus_int32 bitrate)
 {
 	return opus_encoder_ctl(st, OPUS_SET_BITRATE(bitrate));
 }
 
+#cgo noescape bridge_encoder_get_bitrate
+#cgo nocallback bridge_encoder_get_bitrate
 int
 bridge_encoder_get_bitrate(OpusEncoder *st, opus_int32 *bitrate)
 {
 	return opus_encoder_ctl(st, OPUS_GET_BITRATE(bitrate));
 }
 
+#cgo noescape bridge_encoder_set_complexity
+#cgo nocallback bridge_encoder_set_complexity
 int
 bridge_encoder_set_complexity(OpusEncoder *st, opus_int32 complexity)
 {
 	return opus_encoder_ctl(st, OPUS_SET_COMPLEXITY(complexity));
 }
 
+#cgo noescape bridge_encoder_get_complexity
+#cgo nocallback bridge_encoder_get_complexity
 int
 bridge_encoder_get_complexity(OpusEncoder *st, opus_int32 *complexity)
 {
 	return opus_encoder_ctl(st, OPUS_GET_COMPLEXITY(complexity));
 }
 
+#cgo noescape bridge_encoder_set_max_bandwidth
+#cgo nocallback bridge_encoder_set_max_bandwidth
 int
 bridge_encoder_set_max_bandwidth(OpusEncoder *st, opus_int32 max_bw)
 {
 	return opus_encoder_ctl(st, OPUS_SET_MAX_BANDWIDTH(max_bw));
 }
 
+#cgo noescape bridge_encoder_get_max_bandwidth
+#cgo nocallback bridge_encoder_get_max_bandwidth
 int
 bridge_encoder_get_max_bandwidth(OpusEncoder *st, opus_int32 *max_bw)
 {
 	return opus_encoder_ctl(st, OPUS_GET_MAX_BANDWIDTH(max_bw));
 }
 
+#cgo noescape bridge_encoder_set_inband_fec
+#cgo nocallback bridge_encoder_set_inband_fec
 int
 bridge_encoder_set_inband_fec(OpusEncoder *st, opus_int32 fec)
 {
 	return opus_encoder_ctl(st, OPUS_SET_INBAND_FEC(fec));
 }
 
+#cgo noescape bridge_encoder_get_inband_fec
+#cgo nocallback bridge_encoder_get_inband_fec
 int
 bridge_encoder_get_inband_fec(OpusEncoder *st, opus_int32 *fec)
 {
 	return opus_encoder_ctl(st, OPUS_GET_INBAND_FEC(fec));
 }
 
+#cgo noescape bridge_encoder_set_packet_loss_perc
+#cgo nocallback bridge_encoder_set_packet_loss_perc
 int
 bridge_encoder_set_packet_loss_perc(OpusEncoder *st, opus_int32 loss_perc)
 {
 	return opus_encoder_ctl(st, OPUS_SET_PACKET_LOSS_PERC(loss_perc));
 }
 
+#cgo noescape bridge_encoder_get_packet_loss_perc
+#cgo nocallback bridge_encoder_get_packet_loss_perc
 int
 bridge_encoder_get_packet_loss_perc(OpusEncoder *st, opus_int32 *loss_perc)
 {
 	return opus_encoder_ctl(st, OPUS_GET_PACKET_LOSS_PERC(loss_perc));
 }
 
+#cgo noescape bridge_encoder_reset_state
+#cgo nocallback bridge_encoder_reset_state
 int
 bridge_encoder_reset_state(OpusEncoder *st)
 {
 	return opus_encoder_ctl(st, OPUS_RESET_STATE);
 }
 
+#cgo noescape bridge_encoder_get_prev_signal_type
+#cgo nocallback bridge_encoder_get_prev_signal_type
 int
 bridge_encoder_get_prev_signal_type(OpusEncoder *st, opus_int32 *prev_signal_type)
 {
 	return opus_encoder_ctl(st, OPUS_GET_PREVSIGNALTYPE(prev_signal_type));
 }
 
+#cgo noescape bridge_encoder_get_prev_mode
+#cgo nocallback bridge_encoder_get_prev_mode
 int
 bridge_encoder_get_prev_mode(OpusEncoder *st, opus_int32 *prev_mode)
 {

--- a/opus.go
+++ b/opus.go
@@ -32,6 +32,9 @@ const (
 	OPUS_TYPE_NO_VOICE_ACTIVITY = 0
 	OPUS_TYPE_UNVOICED          = 1
 	OPUS_TYPE_VOICED            = 2
+	OPUS_MODE_SILK_ONLY         = 1000
+	OPUS_MODE_HYBRID            = 1001
+	OPUS_MODE_CELT_ONLY         = 1002
 )
 
 func Version() string {


### PR DESCRIPTION
Lets you tell if the encoder/decoder was in CELT/SILK/or Hybrid mode for the previous packet.